### PR TITLE
Remove 'ssh' from PORT_FORWARD_SERVICES

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
       MQ_HOST: "mq"
       HOST_NETWORK: "off"
       MANAGE_IPTABLES: "on"
-      PORT_FORWARD_SERVICES: "mq,dns,ssh"
+      PORT_FORWARD_SERVICES: "mq,dns"
       VERBOSITY: "1"
     ports:
       - "51821-51830:51821-51830/udp"


### PR DESCRIPTION
Default inclusion of 'ssh' in PORT_FORWARD_SERVICES was deprecated with v. 0.12.1, see https://github.com/gravitl/netmaker/issues/864 for context